### PR TITLE
プロモコード期限の範囲指定の修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .clasp.json
+creds.json
+.clasprc.json

--- a/notifyLimitDate.gs.js
+++ b/notifyLimitDate.gs.js
@@ -19,8 +19,8 @@ function notifyLimitDate() {
   let limitList = [];
   data.some(function(value) {
     // 期限が指定の日付以内 かつ チェックボックスにチェックが付いていない
-    if((value[4].getTime()<=dt.getTime())&&(!value[5])){
-      limitList.push([Utilities.formatDate(value[4], "JST", "yyyy/MM/dd"), value[2]])
+    if((value[5].getTime()<=dt.getTime())&&(!value[6])){
+      limitList.push([Utilities.formatDate(value[5], "JST", "yyyy/MM/dd"), value[2]])
     }
   });
   // 期限が近いものがある場合はLINEに通知する


### PR DESCRIPTION
- プロモコードの期限のカラム位置を修正
- `.gitignore`にclaspの認証ファイルを追加
  - 参考：https://qiita.com/jiroshin/items/dcc398285c652554e66a